### PR TITLE
Fix for undefined property error

### DIFF
--- a/Sources/Workflows/AlfredTweet/alfredtweet.php
+++ b/Sources/Workflows/AlfredTweet/alfredtweet.php
@@ -101,7 +101,7 @@ class AlfredTweet
 				'text' => $msg
 			)
 		);
-		if ( $result->error ):
+		if ( isset($result->error) ):
 			echo $result->error;
 			return false;
 		else:
@@ -128,7 +128,7 @@ class AlfredTweet
 				'screen_name' => $user
 			)
 		);
-		if ( $result->error ):
+		if ( isset($result->error) ):
 			echo $result->error;
 			return false;
 		else:
@@ -155,7 +155,7 @@ class AlfredTweet
 				'screen_name' => $user
 			)
 		);
-		if ( $result->error ):
+		if ( isset($result->error) ):
 			echo $result->error;
 			return false;
 		else:
@@ -182,7 +182,7 @@ class AlfredTweet
 				'screen_name' => $user
 			)
 		);
-		if ( $result->error ):
+		if ( isset($result->error) ):
 			echo $result->error;
 			return false;
 		else:
@@ -209,7 +209,7 @@ class AlfredTweet
 				'screen_name' => $user
 			)
 		);
-		if ( $result->error ):
+		if ( isset($result->error) ):
 			echo $result->error;
 			return false;
 		else:
@@ -233,7 +233,7 @@ class AlfredTweet
 				'name' => $name
 			)
 		);
-		if ( $result->error ):
+		if ( isset($result->error) ):
 			echo $result->error;
 			return false;
 		else:
@@ -257,7 +257,7 @@ class AlfredTweet
 				'list_id' => $name
 			)
 		);
-		if ( $result->error ):
+		if ( isset($result->error) ):
 			echo $result->error;
 			return false;
 		else:
@@ -281,7 +281,7 @@ class AlfredTweet
 				'screen_name' => $screen_name
 			)
 		);
-		if ( $result->error ):
+		if ( isset($result->error) ):
 			echo $result->error;
 			return false;
 		else:
@@ -304,7 +304,7 @@ class AlfredTweet
 				'count' => 10
 			)
 		);
-		if ( $result->error ):
+		if ( isset($result->error) ):
 			echo $result->error;
 			return false;
 		else:
@@ -328,7 +328,7 @@ class AlfredTweet
 				'result_type' => 'recent'
 			)
 		);
-		if ( $result->error ):
+		if ( isset($result->error) ):
 			echo $result->error;
 			return false;
 		else:
@@ -363,7 +363,7 @@ class AlfredTweet
 				)
 			);
 		endif;
-		if ( $result->error ):
+		if ( isset($result->error) ):
 			echo $result->error;
 			return false;
 		else:
@@ -386,7 +386,7 @@ class AlfredTweet
 				'count' => 10
 			)
 		);
-		if ( $result->error ):
+		if ( isset($result->error) ):
 			echo $result->error;
 			return false;
 		else:
@@ -405,7 +405,7 @@ class AlfredTweet
 			)
 		);
 
-		if ( $result->error ):
+		if ( isset($result->error) ):
 			echo $result->error;
 			return false;
 		else:
@@ -429,7 +429,7 @@ class AlfredTweet
 			)
 		);
 
-		if ( $result->error ):
+		if ( isset($result->error) ):
 			echo $result->error;
 			return false;
 		else:
@@ -448,7 +448,7 @@ class AlfredTweet
 			)
 		);
 
-		if ( $result->error ):
+		if ( isset($result->error) ):
 			echo $result->error;
 			return false;
 		else:
@@ -466,7 +466,7 @@ class AlfredTweet
 			)
 		);
 
-		if ( $result->error ):
+		if ( isset($result->error) ):
 			echo $result->error;
 			return false;
 		else:


### PR DESCRIPTION
Depending on your php version you get an _undefined property: stdClass::$error in .../alfredtweet.php on line 366_ during authentication process when there is _no_ error!
Wrapping property accessor with isset() fixes the problem.

There are multiple occurrences in alfredtweet.php with missing isset(), which this changes is taking care of.

---

Occurred on 
OS X 10.7.5
PHP 5.3.26 with Suhosin-Patch (cli) (built: Jul  7 2013 18:22:47) 
Copyright (c) 1997-2013 The PHP Group
Zend Engine v2.3.0, Copyright (c) 1998-2013 Zend Technologies
